### PR TITLE
deps: bump community-hub-release-parent from 1.2.2 to 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.2.2</version>
+    <version>1.3.1</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
closes #72 